### PR TITLE
running wmctotrk1.py through brainlife/dipy docker container

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,0 @@
-{
-	"wmc": "/Users/davidhunt/Documents/5bb62c5612512a003f32ed38/output.mat",
-	"t1": "/Users/davidhunt/Documents/t1.nii"
-}

--- a/main
+++ b/main
@@ -6,4 +6,6 @@
 #parse config.json for input parameters (here, we are pulling "output")
 out1=$(jq -r .wmc config.json)
 out2=$(jq -r .t1 config.json)
-./wmctotrk1.py "$out1" "$out2"
+
+#./wmctotrk1.py "$out1" "$out2"
+time singularity exec -e docker://brainlife/dipy:0.14.1 ./wmctotrk1.py "$out1" "$out2"


### PR DESCRIPTION
It was failing on Karst due to the use of outdated python module